### PR TITLE
Export Vec3 class properly in typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare class Vec3 {
+export class Vec3 {
     constructor(x: number, y: number, z: number);
 
     x: number;
@@ -69,10 +69,9 @@ declare class Vec3 {
 
     toArray(): Array<number>;
 }
-declare function v(x: null | Array<number | string> | {x: number | string, y: number | string, z: number | string} | string, y?: number | string, z?: number | string): Vec3;
-type Vec3Constructor = typeof Vec3;
-declare namespace v {
-    const Vec3: Vec3Constructor;
-    export type Vec3 = Vec3Constructor;
-}
-export = v;
+
+export default function v(
+    x: null | Array<number | string> | {x: number | string, y: number | string, z: number | string} | string,
+    y?: number | string,
+    z?: number | string
+): Vec3;


### PR DESCRIPTION
The previously included typings did not export the `Vec3` class directly, but instead exported the `Vec3` constructor. This made it impossible to declare variables in typescript with the type:
```ts
import { Vec3 } from 'vec3';
let v: Vec3;
v = new Vec3(0, 0, 0);
// ^ Property 'prototype' is missing in type 'Vec3' but required in type 'typeof Vec3'.
```