### PR TITLE
Only publish files to npm that are actually required

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "3d vector math with good unit tests",
   "main": "index.js",
   "types": "index.d.ts",
+  "files": [
+    "HISTORY.md",
+    "index.d.ts"
+  ],
   "scripts": {
     "test": "mocha --reporter spec",
     "pretest": "npm run lint",


### PR DESCRIPTION
Limit files that are published to `npm` to only include the files that are actually needed to provide a working lib.