### PR TITLE
Allows simple "import { Vec3 } from 'vec3';" in ES modules.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,7 @@
     "test": "mocha --reporter spec",
     "pretest": "npm run lint",
     "lint": "standard",
-    "fix": "standard --fix",
-    "wrap": "gen-esm-wrapper . ./wrapper.mjs",
-    "prepack": "npm run wrap"
+    "fix": "standard --fix"
   },
   "keywords": [
     "point"
@@ -23,8 +21,7 @@
   "license": "BSD",
   "devDependencies": {
     "mocha": "^9.0.0",
-    "standard": "^16.0.1",
-    "gen-esm-wrapper": "^1.1.2"
+    "standard": "^16.0.1"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -8,16 +8,23 @@
     "test": "mocha --reporter spec",
     "pretest": "npm run lint",
     "lint": "standard",
-    "fix": "standard --fix"
+    "fix": "standard --fix",
+    "wrap": "gen-esm-wrapper . ./wrapper.mjs",
+    "prepack": "npm run wrap"
   },
   "keywords": [
     "point"
   ],
+  "exports": {
+    "require": "./index.js",
+    "import": "./wrapper.mjs"
+  },
   "author": "Andrew Kelley",
   "license": "BSD",
   "devDependencies": {
     "mocha": "^9.0.0",
-    "standard": "^16.0.1"
+    "standard": "^16.0.1",
+    "gen-esm-wrapper": "^1.1.2"
   },
   "dependencies": {}
 }

--- a/wrapper.mjs
+++ b/wrapper.mjs
@@ -1,0 +1,4 @@
+import mod from "./index.js";
+
+export default mod;
+export const Vec3 = mod.Vec3;

--- a/wrapper.mjs
+++ b/wrapper.mjs
@@ -1,4 +1,4 @@
-import mod from "./index.js";
+import mod from './index.js'
 
-export default mod;
-export const Vec3 = mod.Vec3;
+export default mod
+export const Vec3 = mod.Vec3


### PR DESCRIPTION
Adds an ESM wrapper, the generator for the wrapper as a dev dependency, and adds a prepack trigger to ensure the wrapper is kept up to date with the actual exports of the CJS version of the code. [Using a wrapper helps prevent the dual package hazard](https://nodejs.org/api/packages.html#packages_approach_1_use_an_es_module_wrapper), as would otherwise occur if the code was written as ESM and completely transpiled to CJS (or vice versa) and given a second entry point (instanceofs between CJS and ESM imports of the code would fail).