### PR TITLE
Add methods, fix .equals

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,55 +29,61 @@ More available functions are listed below in Test Coverage.
 ## Test Coverage
 
 ```
-v()
-    ✓ no args
-    ✓ x, y, z
-    ✓ array
-    ✓ object
-    ✓ string coords
-    ✓ deserialize
-    ✓ invalid deserialize
+  v()
+    ✔ no args
+    ✔ x, y, z
+    ✔ array
+    ✔ object
+    ✔ string coords
+    ✔ deserialize
+    ✔ invalid deserialize
 
   vec3
-    ✓ rounded
-    ✓ round
-    ✓ floored
-    ✓ floor
-    ✓ offset
-    ✓ translate
-    ✓ plus
-    ✓ minus
-    ✓ scaled
-    ✓ abs
-    ✓ distanceTo
-    ✓ equals
-    ✓ toString
-    ✓ clone
-    ✓ add
-    ✓ subtract
-    ✓ multiply
-    ✓ divide
-    ✓ set
-    ✓ modulus
-    ✓ volume
-    ✓ min
-    ✓ max
-    ✓ update
-    ✓ norm
-    ✓ dot
-    ✓ cross
-    ✓ unit
-    ✓ normalize
-    ✓ scale
-    ✓ xyDistanceTo
-    ✓ xzDistanceTo
-    ✓ yzDistanceTo
-    ✓ innerProduct
-    ✓ manhattanDistanceTo
-    ✓ toArray
+    ✔ isZero
+    ✔ at
+    ✔ xz
+    ✔ xy
+    ✔ yz
+    ✔ xzy
+    ✔ rounded
+    ✔ round
+    ✔ floored
+    ✔ floor
+    ✔ offset
+    ✔ translate
+    ✔ plus
+    ✔ minus
+    ✔ scaled
+    ✔ abs
+    ✔ distanceTo
+    ✔ distanceSquared
+    ✔ equals
+    ✔ toString
+    ✔ clone
+    ✔ add
+    ✔ subtract
+    ✔ multiply
+    ✔ divide
+    ✔ set
+    ✔ modulus
+    ✔ volume
+    ✔ min
+    ✔ max
+    ✔ update
+    ✔ norm
+    ✔ dot
+    ✔ cross
+    ✔ unit
+    ✔ normalize
+    ✔ scale
+    ✔ xyDistanceTo
+    ✔ xzDistanceTo
+    ✔ yzDistanceTo
+    ✔ innerProduct
+    ✔ manhattanDistanceTo
+    ✔ toArray
 
-
-  39 passing
+  50 passing (14ms)
 ```
 
 More functions welcome in the form of pull requests.

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,7 +39,7 @@ export class Vec3 {
    * Set own values to given x y z
    * If some components is given null, then those components won't change
    */
-  set(x: number | null, y: number | null, z: number | null): this;
+  set(x: number, y: number, z: number): this;
 
   /**
    * Set own values to values given by other

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,9 +6,40 @@ export class Vec3 {
   z: number;
 
   /**
-   * Set own values to given x y z
+   * Returns true when it is a zero vector.
    */
-  set(x: number, y: number, z: number): this;
+  isZero(): boolean;
+
+  /**
+   * Access component by index
+   */
+  at(id: number): number;
+
+  /**
+   * Returns an array component x, z
+   */
+  xz(): [number, number];
+
+  /**
+   * Returns an array component x, y
+   */
+  xy(): [number, number];
+
+  /**
+   * Returns an array component y, z
+   */
+  yz(): [number, number];
+
+  /**
+   * Returns a vector with swapped y and z
+   */
+  xzy(): Vec3;
+
+  /**
+   * Set own values to given x y z
+   * If some components is given null, then those components won't change
+   */
+  set(x: number | null, y: number | null, z: number | null): this;
 
   /**
    * Set own values to values given by other
@@ -106,9 +137,10 @@ export class Vec3 {
   distanceSquared(other: Vec3): number;
 
   /**
-   * Returns true when all values match with the values off the other vector
+   * Check whether two vectors are equal
+   * Returns true if each components have at most `error` difference
    */
-  equals(other: Vec3): boolean;
+  equals(other: Vec3, error?: number): boolean;
 
   /**
    * Converts own values to a string representation in the format `(x, y, z)`

--- a/index.js
+++ b/index.js
@@ -32,9 +32,9 @@ class Vec3 {
   }
 
   set (x, y, z) {
-    if (x != null) { this.x = x }
-    if (y != null) { this.y = y }
-    if (z != null) { this.z = z }
+    this.x = x
+    this.y = y
+    this.z = z
     return this
   }
 

--- a/index.js
+++ b/index.js
@@ -7,10 +7,34 @@ class Vec3 {
     this.z = z
   }
 
+  isZero () {
+    return this.x === 0 && this.y === 0 && this.z === 0
+  }
+
+  at (id) {
+    return this.toArray()[id]
+  }
+
+  xz () {
+    return [this.x, this.z]
+  }
+
+  xy () {
+    return [this.x, this.y]
+  }
+
+  yz () {
+    return [this.y, this.z]
+  }
+
+  xzy () {
+    return new Vec3(this.x, this.z, this.y)
+  }
+
   set (x, y, z) {
-    this.x = x
-    this.y = y
-    this.z = z
+    if (x != null) { this.x = x }
+    if (y != null) { this.y = y }
+    if (z != null) { this.z = z }
     return this
   }
 
@@ -123,8 +147,10 @@ class Vec3 {
     return dx * dx + dy * dy + dz * dz
   }
 
-  equals (other) {
-    return this.x === other.x && this.y === other.y && this.z === other.z
+  equals (other, error = Number.EPSILON) {
+    return Math.abs(this.x - other.x) <= error &&
+      Math.abs(this.y - other.y) <= error &&
+      Math.abs(this.z - other.z) <= error
   }
 
   toString () {

--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ class Vec3 {
     return dx * dx + dy * dy + dz * dz
   }
 
-  equals (other, error = Number.EPSILON) {
+  equals (other, error = 0) {
     return Math.abs(this.x - other.x) <= error &&
       Math.abs(this.y - other.y) <= error &&
       Math.abs(this.z - other.z) <= error

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -17,6 +17,12 @@ expectType<number>(vec.x);
 expectType<number>(vec.y);
 expectType<number>(vec.z);
 
+expectType<boolean>(vec.isZero());
+expectType<number>(vec.at(1));
+expectType<[number, number]>(vec.xz());
+expectType<[number, number]>(vec.xy());
+expectType<[number, number]>(vec.yz());
+expectType<Vec3>(vec.xzy());
 expectType<Vec3>(vec.set(4, 5, 6));
 expectType<Vec3>(vec.update(vec));
 expectType<Vec3>(vec.floored());

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,43 @@ describe('v()', function () {
   })
 })
 describe('vec3', function () {
+  it('isZero', function () {
+    const v1 = new Vec3(0, 1, 2)
+    const v2 = new Vec3(0, 0, 0)
+    assert.ok(!v1.isZero())
+    assert.ok(v2.isZero())
+  })
+  it('at', function () {
+    const v1 = new Vec3(0, 1, 2)
+    assert.strictEqual(v1.at(0), 0)
+    assert.strictEqual(v1.at(1), 1)
+    assert.strictEqual(v1.at(2), 2)
+  })
+  it('xz', function () {
+    const v1 = new Vec3(0, 1, 2)
+    const a = v1.xz()
+    assert.strictEqual(a[0], 0)
+    assert.strictEqual(a[1], 2)
+  })
+  it('xy', function () {
+    const v1 = new Vec3(0, 1, 2)
+    const a = v1.xy()
+    assert.strictEqual(a[0], 0)
+    assert.strictEqual(a[1], 1)
+  })
+  it('yz', function () {
+    const v1 = new Vec3(0, 1, 2)
+    const a = v1.yz()
+    assert.strictEqual(a[0], 1)
+    assert.strictEqual(a[1], 2)
+  })
+  it('xzy', function () {
+    const v1 = new Vec3(0, 1, 2)
+    const v2 = v1.xzy()
+    assert.strictEqual(v2.x, 0)
+    assert.strictEqual(v2.y, 2)
+    assert.strictEqual(v2.z, 1)
+  })
   it('rounded', function () {
     const v1 = new Vec3(1.1, -1.5, 1.9)
     const v2 = v1.rounded()
@@ -168,6 +205,10 @@ describe('vec3', function () {
     const v2 = v1.scaled(0.23424)
     const v3 = v1.scaled(0.23424)
     assert.ok(v2.equals(v3))
+    const v4 = new Vec3(0.1, 0, 0)
+    const v5 = new Vec3(0.2, 0, 0)
+    const v6 = new Vec3(0.3, 0, 0)
+    assert.ok(v4.plus(v5).equals(v6))
   })
   it('toString', function () {
     const v1 = new Vec3(1, -1, 3.14)
@@ -226,6 +267,10 @@ describe('vec3', function () {
     assert.strictEqual(v1, v2)
     assert.strictEqual(v1.x, 0)
     assert.strictEqual(v1.y, 10)
+    assert.strictEqual(v1.z, 100)
+    v1.set(10, 0, null)
+    assert.strictEqual(v1.x, 10)
+    assert.strictEqual(v1.y, 0)
     assert.strictEqual(v1.z, 100)
   })
   it('modulus', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -208,7 +208,7 @@ describe('vec3', function () {
     const v4 = new Vec3(0.1, 0, 0)
     const v5 = new Vec3(0.2, 0, 0)
     const v6 = new Vec3(0.3, 0, 0)
-    assert.ok(v4.plus(v5).equals(v6))
+    assert.ok(v4.plus(v5).equals(v6, Number.EPSILON))
   })
   it('toString', function () {
     const v1 = new Vec3(1, -1, 3.14)

--- a/test/test.js
+++ b/test/test.js
@@ -268,10 +268,6 @@ describe('vec3', function () {
     assert.strictEqual(v1.x, 0)
     assert.strictEqual(v1.y, 10)
     assert.strictEqual(v1.z, 100)
-    v1.set(10, 0, null)
-    assert.strictEqual(v1.x, 10)
-    assert.strictEqual(v1.y, 0)
-    assert.strictEqual(v1.z, 100)
   })
   it('modulus', function () {
     const v1 = new Vec3(12, 32, -1)


### PR DESCRIPTION
Added methods:

- `.xz()`, `.xy()`, `.yz()` for accessing interested parts only
- `.xzy()` for a vector with y and z swapped.
- `.at(index)` a shortcut for `.toArray()[index]`
- `isZero()` checks for zero vector

Changed methods:

- `.equals()`: Usually we can't use `===` for comparing two floats, which leads to `0.1 + 0.2 !== 0.3`.
- ~`.set()`: Now we can pass null to those component we don't want to change.~ not a good design.
